### PR TITLE
Increase max body size to support larger uploads

### DIFF
--- a/files/nginx.conf
+++ b/files/nginx.conf
@@ -32,7 +32,7 @@ http {
     client_header_timeout     10;
 
     client_header_buffer_size 128;
-    client_max_body_size      8m;
+    client_max_body_size      20m;
 
     open_file_cache           max=1000 inactive=20s;
     open_file_cache_valid     30s;


### PR DESCRIPTION
We need a bit more head room to upload our RV/SMR import CSV files which
can be a bit large. Increasing this seems like the simplest solution for
now but if we find we need to support even bigger files in future then
we should probably consider implementing Rails' client-side uploads.

This will enable Naureen to finish testing this PR:
https://github.com/tusker-direct/hobgoblin/pull/949